### PR TITLE
refactor: 🚀 update deploy port from `8080` to `8000`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 # Copy the application code to the working directory
 COPY ./main.py /app/
 
-EXPOSE 8080
+EXPOSE 8000
 
 # Run the FastAPI application using uvicorn server
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,5 @@ services:
     build:
       context: '.'
     ports:
-      - 8080:8080
+      - 8000:8000
     env_file: .env


### PR DESCRIPTION
It seems weird to have a Dev Port and another Port for the Docker Container, so just standardized it to work with port 8000 for both 